### PR TITLE
Convert the awscli bash commands to Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-Collection of the AWS Managed IAM policies.  These were acquired as follows:
+Collection of the AWS Managed IAM policies.  These are acquired by the `get_aws_managed_policies.py` script.
 
 ```
-aws iam list-policies > list-policies.json
-cat list-policies.json | jq -cr '.Policies[] | select(.Arn | contains("iam::aws"))|.Arn +" "+ .DefaultVersionId+" "+.PolicyName' | xargs -n3 sh -c 'aws iam get-policy-version --policy-arn $1 --version-id $2 > "policies/$3"' sh
+python3 get_aws_managed_policies.py
 ```
 
-This does the following:
-- Gets the list of all policies in the account
-- Finds the ones with an ARN containing "iam::aws", so that only the AWS managed policies are grabbed.
+This script does the following:
+- Gets the list of all policies in the account with scope AWS (managed by AWS).
 - Gets the ARN, current version id, and policy name (needed so we don't have a slash like the ARN does for writing a file)
-- Calls `aws iam get-policy-version` with those values, and writes the output to a file using the policy name.
+- Calls `get-policy-version` with those values, and writes the output to a file using the policy name.

--- a/get_aws_managed_policies.py
+++ b/get_aws_managed_policies.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""
+Get all AWS Managed Policies and output the current version
+"""
+
+import datetime
+import json
+
+import boto3
+
+
+IAM_CLIENT = boto3.client("iam")
+
+
+def use_aws_timestamp_fmt(o):
+    """
+    Convert Timestamps to the ISO 8601 Variation AWS Uses
+    """
+    if isinstance(o, (datetime.date, datetime.datetime)):
+        return o.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def get_all_aws_iam_policies(max_items=100):
+    """
+    Yield all current AWS Managed IAM Policies
+    """
+    has_more = True
+    marker = None
+
+    while has_more is True:
+        if marker:
+            resp = IAM_CLIENT.list_policies(
+                Scope="AWS", MaxItems=max_items, Marker=marker
+            )
+        else:
+            resp = IAM_CLIENT.list_policies(Scope="AWS", MaxItems=max_items)
+
+        for policy in resp["Policies"]:
+            yield policy
+
+        has_more = resp["IsTruncated"]
+
+        if has_more:
+            marker = resp["Marker"]
+
+
+def update_policy_version_doc(policy):
+    with open("policies/" + policy["PolicyName"], "w") as fw:
+        response = IAM_CLIENT.get_policy_version(
+            PolicyArn=policy["Arn"], VersionId=policy["DefaultVersionId"]
+        )
+
+        del response["ResponseMetadata"]
+
+        json.dump(response, fw, default=use_aws_timestamp_fmt, indent=4)
+        fw.write("\n")  # Old process included a newline
+
+
+def main():
+    for policy in get_all_aws_iam_policies():
+        update_policy_version_doc(policy)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Quick conversion from the awscli and bash commands to Python. This
enables future plans to automate the updates to this repository and to
run this in AWS Lambda.

Python outputs the same policy document json that the old process does.