### PR TITLE
AWS Lambda automate updating policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,162 @@
 list-policies.json
+
+# Python
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# AWS CDK
+# VSCode extension
+.vscode/
+/.favorites.json
+
+# TypeScript incremental build states
+*.tsbuildinfo
+
+# Local state files & OS specifics
+.DS_Store
+node_modules/
+lerna-debug.log
+dist/
+pack/
+.BUILD_COMPLETED
+.local-npm/
+.tools/
+coverage/
+.nyc_output
+.LAST_BUILD
+*.sw[a-z]
+*~
+
+# We don't want tsconfig at the root
+/tsconfig.json
+
+# CDK Context & Staging files
+cdk.context.json
+.cdk.staging/
+cdk.out/
+
+# Lambda Package Builds
+deploymentPackage.zip
+lambda_package/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Collection of the AWS Managed IAM policies.  These are acquired by the `get_aws_managed_policies.py` script.
 
 ```
-python3 get_aws_managed_policies.py
+python3 auto_update_lambda/get_aws_managed_policies.py
 ```
 
 This script does the following:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-Collection of the AWS Managed IAM policies.  These were acquired as follows:
+Collection of the AWS Managed IAM policies.  These are acquired by the `get_aws_managed_policies.py` script.
 
 ```
-aws iam list-policies > list-policies.json
-cat list-policies.json | jq -cr '.Policies[] | select(.Arn | contains("iam::aws"))|.Arn +" "+ .DefaultVersionId+" "+.PolicyName' | xargs -n3 sh -c 'aws iam get-policy-version --policy-arn $1 --version-id $2 > "policies/$3"' sh
+python3 get_aws_managed_policies.py
 ```
 
-This does the following:
-- Gets the list of all policies in the account
-- Finds the ones with an ARN containing "iam::aws", so that only the AWS managed policies are grabbed.
+This script does the following:
+- Gets the list of all policies in the account with scope AWS (managed by AWS).
 - Gets the ARN, current version id, and policy name (needed so we don't have a slash like the ARN does for writing a file)
-- Calls `aws iam get-policy-version` with those values, and writes the output to a file using the policy name.
+- Calls `get-policy-version` with those values, and writes the output to a file using the policy name.

--- a/auto_update_lambda/app.py
+++ b/auto_update_lambda/app.py
@@ -1,0 +1,108 @@
+"""
+Prior to running this CDK, a few prerequisites.
+
+1) Put the GitHub Personal Access Token Secret in AWS Secrets Manager and
+setup other environmental variables.
+
+Create a Secret in account that is the Personal Access Token for the account to
+push to the target repo.
+
+Get the ARN for the created Secret and add an environmental variable with name
+AMP_GH_ACCESS_TOKEN_ARN and the ARN as the value.
+
+The following additional environment variables need to be set.
+GH_BOT_USERNAME   - Bot Username associated with the access token
+GH_BOT_REPO_OWNER - GitHub Repo Owner - Username or Org
+GH_BOT_COMMITTER  - Author/Committer String for Git
+
+2) Build the Lambda Deployment Package for the Lambda Code.
+
+```
+mkdir lambda_package; cd lambda_package/
+cp ../get_aws_managed_policies.py ../lambda-handler.py .
+pip3 install dulwich -t .
+zip -r ../deploymentPackage.zip .
+```
+
+3) Perform the normal AWS CDK Deployment process
+"""
+
+
+from os import environ
+
+from aws_cdk import (
+    aws_events as events,
+    aws_events_targets as targets,
+    aws_iam,
+    aws_lambda as lambda_,
+    aws_logs,
+    aws_secretsmanager as secret_,
+    core,
+)
+
+
+class AWSManagedPolicyUpdater(core.Stack):
+    def __init__(self, app: core.App, id: str) -> None:
+        super().__init__(app, id)
+
+        role = aws_iam.Role(
+            self,
+            "getAWSPoliciesRoleLambda",
+            assumed_by=aws_iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                aws_iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaBasicExecutionRole"
+                )
+            ],
+        )
+
+        aws_iam.Policy(
+            self,
+            "iam_list_policies",
+            policy_name="iam_list_policies",
+            statements=[
+                aws_iam.PolicyStatement(
+                    actions=[
+                        "iam:GetPolicyVersion",
+                        "iam:ListPolicies",
+                        "iam:ListPolicyVersions",
+                    ],
+                    resources=["*"],
+                )
+            ],
+            roles=[role],
+        )
+
+        secret = secret_.Secret.from_secret_attributes(
+            self, "Secret", secret_arn=environ["AMP_GH_ACCESS_TOKEN_ARN"]
+        )
+
+        secret.grant_read(role)
+
+        lambdaFn = lambda_.Function(
+            self,
+            "AWSManagedPolicyUpdater",
+            code=lambda_.AssetCode("./deploymentPackage.zip"),
+            handler="lambda-handler.main",
+            timeout=core.Duration.minutes(15),
+            runtime=lambda_.Runtime.PYTHON_3_7,
+            role=role,
+            environment={
+                "GH_BOT_USERNAME": environ["GH_BOT_USERNAME"],
+                "GH_BOT_REPO_OWNER": environ["GH_BOT_REPO_OWNER"],
+                "GH_BOT_COMMITTER": environ["GH_BOT_COMMITTER"],
+            },
+        )
+
+        # Run once every hour on the 9th minute
+        # See https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html
+        rule = events.Rule(
+            self, "Rule", schedule=events.Schedule.cron(minute="9", hour="*")
+        )
+
+        rule.add_target(targets.LambdaFunction(lambdaFn))
+
+
+app = core.App()
+AWSManagedPolicyUpdater(app, "AWSManagedPolicyUpdater")
+app.synth()

--- a/auto_update_lambda/cdk.json
+++ b/auto_update_lambda/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/auto_update_lambda/get_aws_managed_policies.py
+++ b/auto_update_lambda/get_aws_managed_policies.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 """
-Get all AWS Managed Policies and output the current version
+Get all AWS Managed Policies, output to files and commit to git repo.
 """
 
 import datetime
 import json
+import os
 
 import boto3
 
@@ -46,6 +47,9 @@ def get_all_aws_iam_policies(max_items=100):
 
 
 def update_policy_version_doc(policy):
+    """
+    Write out each AWS Managed Policy a JSON File.
+    """
     with open("policies/" + policy["PolicyName"], "w") as fw:
         response = IAM_CLIENT.get_policy_version(
             PolicyArn=policy["Arn"], VersionId=policy["DefaultVersionId"]
@@ -57,9 +61,13 @@ def update_policy_version_doc(policy):
         fw.write("\n")  # Old process included a newline
 
 
-def main():
+def get_all_aws_managed_policies():
     for policy in get_all_aws_iam_policies():
         update_policy_version_doc(policy)
+
+
+def main():
+    get_all_aws_managed_policies()
 
 
 if __name__ == "__main__":

--- a/auto_update_lambda/lambda-handler.py
+++ b/auto_update_lambda/lambda-handler.py
@@ -1,0 +1,130 @@
+import base64
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+
+from dulwich import porcelain
+from get_aws_managed_policies import *
+
+
+def get_secret():
+    """
+    AWS Provided Get Secret Code
+    """
+    secret_name = "AMP_GH_ACCESS_TOKEN"
+
+    # Create a Secrets Manager client
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager")
+
+    # In this sample we only handle the specific exceptions for the 'GetSecretValue' API.
+    # See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
+    # We rethrow the exception by default.
+
+    try:
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "DecryptionFailureException":
+            # Secrets Manager can't decrypt the protected secret text using the provided KMS key.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response["Error"]["Code"] == "InternalServiceErrorException":
+            # An error occurred on the server side.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response["Error"]["Code"] == "InvalidParameterException":
+            # You provided an invalid value for a parameter.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response["Error"]["Code"] == "InvalidRequestException":
+            # You provided a parameter value that is not valid for the current state of the resource.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+        elif e.response["Error"]["Code"] == "ResourceNotFoundException":
+            # We can't find the resource that you asked for.
+            # Deal with the exception here, and/or rethrow at your discretion.
+            raise e
+    else:
+        # Decrypts secret using the associated KMS CMK.
+        # Depending on whether the secret is a string or binary, one of these fields will be populated.
+
+        if "SecretString" in get_secret_value_response:
+            secret = get_secret_value_response["SecretString"]
+
+    return secret
+
+
+def update_repo(
+    github_bot_username,
+    gh_access_token,
+    repo_owner,
+    repo_path="/tmp/aws_managed_policies",
+):
+    remote_repo = (
+        "https://"
+        + github_bot_username
+        + ":"
+        + gh_access_token
+        + "@github.com/"
+        + repo_owner
+        + "/aws_managed_policies"
+    )
+
+    if os.path.isdir(repo_path):
+        porcelain.pull(repo_path, remote_location=remote_repo)
+    else:
+        porcelain.clone(remote_repo, repo_path)
+
+    os.chdir(repo_path)
+
+
+def commit_any_changes(
+    github_bot_username,
+    gh_access_token,
+    repo_owner,
+    committer,
+    repo_path="/tmp/aws_managed_policies",
+):
+    remote_repo = (
+        "https://"
+        + github_bot_username
+        + ":"
+        + gh_access_token
+        + "@github.com/"
+        + repo_owner
+        + "/aws_managed_policies"
+    )
+
+    os.chdir(repo_path)
+    repo = porcelain.open_repo(repo_path)
+    status = porcelain.status(repo_path)
+
+    # Nothing changed - exit
+    if len(status.unstaged + status.untracked) == 0:
+        return
+
+    repo.stage(status.unstaged + status.untracked)
+
+    porcelain.commit(
+        repo_path,
+        message="Update Managed Policies",
+        author=committer,
+        committer=committer,
+    )
+    porcelain.push(repo_path, remote_repo, "master")
+
+
+def main(event, context):
+    GH_ACCESS_TOKEN = get_secret()
+
+    update_repo(
+        os.environ["GH_BOT_USERNAME"], GH_ACCESS_TOKEN, os.environ["GH_BOT_REPO_OWNER"]
+    )
+    get_all_aws_managed_policies()
+    commit_any_changes(
+        os.environ["GH_BOT_USERNAME"],
+        GH_ACCESS_TOKEN,
+        os.environ["GH_BOT_REPO_OWNER"],
+        os.environ["GH_BOT_COMMITTER"],
+    )

--- a/auto_update_lambda/requirements.txt
+++ b/auto_update_lambda/requirements.txt
@@ -1,0 +1,9 @@
+aws-cdk.aws-events
+aws-cdk.aws-events-targets
+aws-cdk.aws-lambda
+aws-cdk.aws_events
+aws-cdk.aws_iam
+aws-cdk.aws_lambda
+aws-cdk.aws_logs
+aws-cdk.aws_secretsmanager
+aws-cdk.core

--- a/get_aws_managed_policies.py
+++ b/get_aws_managed_policies.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""
+Get all AWS Managed Policies and output the current version
+"""
+
+import datetime
+import json
+
+import boto3
+
+
+IAM_CLIENT = boto3.client("iam")
+
+
+def use_aws_timestamp_fmt(o):
+    """
+    Convert Timestamps to the ISO 8601 Variation AWS Uses
+    """
+    if isinstance(o, (datetime.date, datetime.datetime)):
+        return o.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def get_all_aws_iam_policies(max_items=100):
+    """
+    Yield all current AWS Managed IAM Policies
+    """
+    has_more = True
+    marker = None
+
+    while has_more is True:
+        if marker:
+            resp = IAM_CLIENT.list_policies(
+                Scope="AWS", MaxItems=max_items, Marker=marker
+            )
+        else:
+            resp = IAM_CLIENT.list_policies(Scope="AWS", MaxItems=max_items)
+
+        for policy in resp["Policies"]:
+            yield policy
+
+        has_more = resp["IsTruncated"]
+
+        if has_more:
+            marker = resp["Marker"]
+
+
+def update_policy_version_doc(policy):
+    with open("policies/" + policy["PolicyName"], "w") as fw:
+        response = IAM_CLIENT.get_policy_version(
+            PolicyArn=policy["Arn"], VersionId=policy["DefaultVersionId"]
+        )
+
+        del response["ResponseMetadata"]
+
+        json.dump(response, fw, default=use_aws_timestamp_fmt, indent=4)
+        fw.write("\n")  # Old process included a newline
+
+
+def main():
+    for policy in get_all_aws_iam_policies():
+        update_policy_version_doc(policy)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Using AWS Lambda, configured via the AWS CDK.

Python `dulwich` module to perform git operations. `get_aws_managed_policies.py` still works as before.

See `app.py` doc string for details on setting up and configuring.